### PR TITLE
Some fix

### DIFF
--- a/data.py
+++ b/data.py
@@ -1,28 +1,28 @@
+import multiprocessing
 import threading
-
+import time
 import numpy as np
 import tensorflow as tf
 
 
 def load_data():
     # custom it with your data loader here.
-    for i in range(int(1e9)):
-        yield np.random.uniform(size=(5, 5))
+    for i in xrange(10000):
+        yield np.random.uniform(size=(29))
 
 
 class DataGenerator(object):
     def __init__(self,
                  coord,
-                 queue_size=32):
+                 max_queue_size=32):
         # Change the shape of the input data here with the parameter shapes.
-        self.queue = tf.PaddingFIFOQueue(queue_size, ['float32'], shapes=[(None, None)])
+        self.max_queue_size = max_queue_size
+        self.queue = tf.FIFOQueue(max_queue_size, ['float32'], shapes=[29])
+        self.queue_size = self.queue.size()
         self.threads = []
         self.coord = coord
-        self.sample_placeholder = tf.placeholder(dtype=tf.float32, shape=None)
+        self.sample_placeholder = tf.placeholder(dtype=tf.float32, shape=[29])
         self.enqueue = self.queue.enqueue([self.sample_placeholder])
-
-    def size(self):
-        return self.queue.size()
 
     def dequeue(self, num_elements):
         output = self.queue.dequeue_many(num_elements)
@@ -33,14 +33,19 @@ class DataGenerator(object):
         while not stop:
             iterator = load_data()
             for data in iterator:
+                while self.queue_size.eval(session=sess) == self.max_queue_size:
+                    if self.coord.should_stop():
+                        break
+                    time.sleep(0.02)
                 if self.coord.should_stop():
                     stop = True
+                    print("Process -1 receive stop request.")
                     break
                 sess.run(self.enqueue, feed_dict={self.sample_placeholder: data})
 
     def start_threads(self, sess, n_threads=1):
         for _ in range(n_threads):
-            thread = threading.Thread(target=self.thread_main, args=(sess,))
+            thread = threading.Thread(target=self.thread_main, args=(sess, ))
             thread.daemon = True  # Thread will close when parent quits.
             thread.start()
             self.threads.append(thread)

--- a/data.py
+++ b/data.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 
 def load_data():
     # custom it with your data loader here.
-    for i in range(100):
+    for i in range(10000):
         yield np.random.uniform(size=(5, 5))
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 
+import time
+
 import tensorflow as tf
+
 from data import DataGenerator
 
 
@@ -23,9 +26,10 @@ def main():
     threads = reader.start_threads(sess)
     net = define_net(input_batch)
     queue_size = reader.queue_size
-    for step in range(100):
+    for step in range(10000):
         print('size queue =', queue_size.eval(session=sess))
         print(sess.run(net))
+        time.sleep(1) # Make this thread slow.
 
     coord.request_stop()
     print("stop requested.")

--- a/main.py
+++ b/main.py
@@ -9,7 +9,8 @@ def define_net(input_batch):
 
 
 def main():
-    batch_size = 2
+    batch_size = 1
+
     coord = tf.train.Coordinator()
     with tf.name_scope('create_inputs'):
         reader = DataGenerator(coord)
@@ -22,7 +23,7 @@ def main():
     threads = reader.start_threads(sess)
     net = define_net(input_batch)
     queue_size = reader.queue_size
-    for step in xrange(10000):
+    for step in range(100):
         print('size queue =', queue_size.eval(session=sess))
         print(sess.run(net))
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,6 @@
 from __future__ import print_function
 
-import time
-
 import tensorflow as tf
-
 from data import DataGenerator
 
 
@@ -12,8 +9,7 @@ def define_net(input_batch):
 
 
 def main():
-    batch_size = 1
-
+    batch_size = 2
     coord = tf.train.Coordinator()
     with tf.name_scope('create_inputs'):
         reader = DataGenerator(coord)
@@ -23,20 +19,17 @@ def main():
     init = tf.global_variables_initializer()
     sess.run(init)
 
-    threads = tf.train.start_queue_runners(sess=sess, coord=coord)
-    reader.start_threads(sess)
-
+    threads = reader.start_threads(sess)
     net = define_net(input_batch)
-
-    for step in range(int(1e9)):
-        # The queue is filled faster than what the main thread can unstack.
-        # That's the reason why size of the queue is almost always equal to 32.
-        print('size queue =', sess.run(reader.size()))
+    queue_size = reader.queue_size
+    for step in xrange(10000):
+        print('size queue =', queue_size.eval(session=sess))
         print(sess.run(net))
-        time.sleep(3) # Make this thread slow.
 
     coord.request_stop()
-    coord.join(threads)
+    print("stop requested.")
+    for thread in threads:
+        thread.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fix memory bug caused by `range(int(1e9))`
delete `tf.train.start_queue_runners()`: not necessary
fix thread blocked on `sess.run(enqueue)` and can not be killed bug: modify `thread_main()` in data.py

`reader.size()` in the original code will create a new Tensor represent the size of queue, should not be called multiple times. fix that also.